### PR TITLE
Fixed broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Unit tests and some example applications are provided for each of these; see the
 `paip/tests` and `paip/examples` directories or the links from the annotated
 sources.
 
-[GPS]: http://dhconnelly.github.com/paip-python/docs/paip/gps.html
-[Eliza]: http://dhconnelly.github.com/paip-python/docs/paip/eliza.html
-[Search]: http://dhconnelly.github.com/paip-python/docs/paip/search.html
-[Logic]: http://dhconnelly.github.com/paip-python/docs/paip/logic.html
-[Prolog]: http://dhconnelly.github.com/paip-python/docs/prolog.html
-[Emycin]: http://dhconnelly.github.com/paip-python/docs/paip/emycin.html
-[Othello]: http://dhconnelly.github.com/paip-python/docs/paip/othello.html
+[GPS]: http://dhconnelly.github.io/paip-python/docs/paip/gps.html
+[Eliza]: http://dhconnelly.github.io/paip-python/docs/paip/eliza.html
+[Search]: http://dhconnelly.github.io/paip-python/docs/paip/search.html
+[Logic]: http://dhconnelly.github.io/paip-python/docs/paip/logic.html
+[Prolog]: http://dhconnelly.github.io/paip-python/docs/prolog.html
+[Emycin]: http://dhconnelly.github.io/paip-python/docs/paip/emycin.html
+[Othello]: http://dhconnelly.github.io/paip-python/docs/paip/othello.html
 
 Getting Started
 ---------------


### PR DESCRIPTION
https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/

Subdomains of github.com are deprecated for GitHub Pages. They will not redirect to github.io after April 15, 2021.